### PR TITLE
feat: show all blog posts on homepage

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -5,19 +5,19 @@ import { LayoutTheme, Padding, TransitionType } from "@snokam/core/layout";
 import { GetServerSideProps } from "next";
 
 interface HomePageProps {
-  post: Post | null;
+  posts: Post[];
 }
 
 export const getServerSideProps: GetServerSideProps<HomePageProps> = async () => {
   try {
-    const posts = await getPosts({ limit: 1 });
-    return { props: { post: posts[0] || null } };
+    const posts = await getPosts();
+    return { props: { posts } };
   } catch (error) {
-    return { props: { post: null } };
+    return { props: { posts: [] } };
   }
 };
 
-const HomePage = ({ post }: HomePageProps) => (
+const HomePage = ({ posts }: HomePageProps) => (
   <Page>
     <Layout.Container
       theme={LayoutTheme.Light}
@@ -30,13 +30,38 @@ const HomePage = ({ post }: HomePageProps) => (
       <Layout.Content>
         <Layout.Section padding={{ bottom: Padding.Large }}>
           <h1>Cursor Workshop</h1>
-          {post ? (
-            <>
-              <h3>{post.title}</h3>
-              <p>{post.excerpt}</p>
-            </>
-          ) : (
+          <h2>All Blog Posts</h2>
+          {posts.length === 0 ? (
             <p>No posts found</p>
+          ) : (
+            <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+              {posts.map((post) => (
+                <li
+                  key={post.id}
+                  style={{
+                    borderBottom: "1px solid #e0e0e0",
+                    paddingBottom: "1.5rem",
+                    marginBottom: "1.5rem",
+                  }}
+                >
+                  <h3 style={{ margin: "0 0 0.5rem" }}>{post.title}</h3>
+                  <p style={{ margin: "0 0 0.5rem", color: "#555" }}>
+                    {post.excerpt}
+                  </p>
+                  <small style={{ color: "#888" }}>
+                    By {post.author} &middot;{" "}
+                    {new Date(post.publishedAt).toLocaleDateString("en-US", {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    })}
+                    {post.tags.length > 0 && (
+                      <> &middot; {post.tags.join(", ")}</>
+                    )}
+                  </small>
+                </li>
+              ))}
+            </ul>
           )}
         </Layout.Section>
       </Layout.Content>


### PR DESCRIPTION
Replaces the single-post preview with a full list of all blog posts. Each post displays its title, excerpt, author, date, and tags.

Closes #1

Generated with [Claude Code](https://claude.ai/code)